### PR TITLE
Drive "magic" MPEG video correction from "magic keys" provided by the emulated game.

### DIFF
--- a/NOTES_MPEG.md
+++ b/NOTES_MPEG.md
@@ -50,19 +50,22 @@ Facts:
 
 * Can the `f_code` update per picture as with standard MPEG-1 video, or is it limited to one static forward/backward static value pair per MPEG file/sequence?
 * What is the exact relationship between temporal sequence number and `f_code`?
+* How exactly does the `driver_call(9, X, 0208h, ...)` (aka. "Magic Key") call directly impact this?
 
 ## Current Emulator Workaround
 
-A truthful `f_code` value appears to be in all P and B pictures with a temporal
-sequence number of either 3 or 8, so I am currently seeking to the first P or B 
-picture header matching these criteria, and applying a static `f_code`
-value to all forward and backward motion vector `f_code` values for
-magical MPEG files.
-
-For picture headers containing empty "user data", I use 4 as the truthful
-temporal sequence number. (The Horde)
+The emulator takes uses `driver_call(9, X, 0208h, ...)` (aka "Set Magic Key") to determine where to find a
+truthful `f_code` value which gets applied to the entire MPEG asset when a "magical" `picture_rate` code
+is specified. The MPEG asset file is quickly scrubbed at media handle open time to find a matchiing P or B
+picture containing a truthful `f_code` value. Then this value is statically applied to the entire decoding
+of said MPEG asset file.
 
 Eventually, I think this needs to be handled on a per-picture basis.
+
+Known "magic key" values:
+
+* 0x40044041 -- Default value. Truthful `f_code` found in temporal sequence number of 3 or 8.
+* 0xC39D7088 -- Used in The Horde. Truthful `f_code` found in temporal sequence number of 4.
 
 
 ## Analyzing and Inspecting These Files

--- a/README.md
+++ b/README.md
@@ -81,12 +81,13 @@ configure anything to have a working ReelMagic setup as the defaults will
 enable ReelMagic emulation.
 The parameters are:
 
-* `enabled`        -- Enables/disables the ReelMagic emulator. By default this is `true`
-* `alwaysresident` -- This forces `FMPDRV.EXE` to always be loaded.  By default this is `false`
-* `vgadup5hack`    -- Duplicate every 5th VGA line to help give output a 4:3 ratio. By default this is `false`
-* `magicfhack`     -- Use for MPEG video debugging purposes only. See `reelmagic_player.cpp` for what exactly this does to the MPEG decoder.
-* `a204debug`      -- Controls FMPDRV.EXE function Ah subfunction 204h debug logging. Only applicable in "heavy debugging" build.
-* `a206debug`      -- Controls FMPDRV.EXE function Ah subfunction 206h debug logging. Only applicable in "heavy debugging" build.
+* `enabled`         -- Enables/disables the ReelMagic emulator. By default this is `true`
+* `alwaysresident`  -- This forces `FMPDRV.EXE` to always be loaded.  By default this is `false`
+* `vgadup5hack`     -- Duplicate every 5th VGA line to help give output a 4:3 ratio. By default this is `false`
+* `initialmagickey` -- Provides and alternate value for the initial global "magic key" value in hex. Defaults to 40044041.
+* `magicfhack`      -- Use for MPEG video debugging purposes only. See `reelmagic_player.cpp` for what exactly this does to the MPEG decoder.
+* `a204debug`       -- Controls FMPDRV.EXE function Ah subfunction 204h debug logging. Only applicable in "heavy debugging" build.
+* `a206debug`       -- Controls FMPDRV.EXE function Ah subfunction 206h debug logging. Only applicable in "heavy debugging" build.
 
 
 For example:

--- a/dosbox-0.74-3/src/dosbox.cpp
+++ b/dosbox-0.74-3/src/dosbox.cpp
@@ -661,12 +661,14 @@ void DOSBOX_Init(void) {
 	Pbool->Set_help("Force the FMPDRV.EXE to always be resident and not unloadable.");
 	Pbool = secprop->Add_bool("vgadup5hack",Property::Changeable::OnlyAtStart,false);
 	Pbool->Set_help("Enable the VGA DUP5 Hack. Duplicate's every VGA 5th line.");
-    Pint = secprop->Add_int("audiolevel", Property::Changeable::OnlyAtStart,150);
+	Pint = secprop->Add_int("audiolevel", Property::Changeable::OnlyAtStart,150);
 	Pint->Set_help("Sets the MPEG audio sample level in percents. Defaults to 150%");
-    Pint = secprop->Add_int("audiofifosize", Property::Changeable::OnlyAtStart,30);
+	Pint = secprop->Add_int("audiofifosize", Property::Changeable::OnlyAtStart,30);
 	Pint->Set_help("Sets the MPEG audio frame FIFO size. Defaults to 30 MPEG audio frames.");
-    Pint = secprop->Add_int("audiofifodispose", Property::Changeable::OnlyAtStart,2);
+	Pint = secprop->Add_int("audiofifodispose", Property::Changeable::OnlyAtStart,2);
 	Pint->Set_help("Sets the count of MPEG audio frames to dispose of when the MPEG is going faster than audio-side of things and the FIFO hits max. Defaults to 2.");
+	Pstring = secprop->Add_string("initialmagickey",Property::Changeable::OnlyAtStart,"40044041");
+	Pstring->Set_help("Provides and alternate value for the initial global \"magic key\" value in hex. Defaults to 40044041.");
 	Pint = secprop->Add_int("magicfhack",Property::Changeable::OnlyAtStart,0);
 	Pint->Set_help("MPEG debugging only! Consult the reelmagic_player.cpp source code and NOTES_MPEG.md");
 	Pbool = secprop->Add_bool("a204debug",Property::Changeable::OnlyAtStart,true);

--- a/example.dosbox.conf
+++ b/example.dosbox.conf
@@ -266,6 +266,8 @@ alwaysresident=true
 #audiolevel=150
 #audiofifosize=30
 #audiofifodispose=2
+#initialmagickey=40044041
+#initialmagickey=C39D7088
 #a204debug=false
 #a206debug=false
 


### PR DESCRIPTION

for issue #117